### PR TITLE
add a trigger to run man and bump node from 12 to 16

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,5 +1,6 @@
 name: Update gist with WakaTime summary
 on:
+  workflow_dispatch:
   schedule:
     - cron: '40 1 * * *'
 jobs:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -15,3 +15,6 @@ jobs:
           GIST_ID: ${{ secrets.GIST_ID}}
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           SCU_KEY: ${{ secrets.SCU_KEY }}
+          
+          
+          

--- a/action.yml
+++ b/action.yml
@@ -4,5 +4,5 @@ branding:
   icon: 'clipboard'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,8 +101,8 @@
       }
     },
     "@types/node": {
-      "version": "13.7.1",
-      "resolved": "https://npm.hypers.cc/@types%2fnode/-/node-13.7.1.tgz",
+      "version": "16.0.0",
+      "resolved": "https://npm.hypers.cc/@types%2fnode/-/node-16.0.0.tgz",
       "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
     },
     "@zeit/ncc": {


### PR DESCRIPTION
1. I added a trigger named ```work_dispatch``` in the ```schedule.yml``` to run the workflow manually through reading [Manually running a workflow - GitHub Docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
After that there will be a run manually button of the workflow otherwise there is nothing.
Or We should edit ```README.md``` to explain clearly how to run manually .Well, maybe I'm too fresh.
![image.png](https://yoaken-1316330335.cos.ap-chongqing.myqcloud.com/markdownPic/202301051550715.png)
2. I get a warning when finishing running the workflow that says :"update-gist:Node.js 12 actions are deprecated. For more information see:https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: superman66/wakatime-sync@master". 
I have updated node12 to 16 in my file ```action.yml```. 
It doesn't matter and may becomes a bug for needing more configuration but just a try .
![image.png](https://yoaken-1316330335.cos.ap-chongqing.myqcloud.com/markdownPic/202301051548710.png)
After modified configuration in ```package-lock.json``` and use my own respository......
![image.png](https://yoaken-1316330335.cos.ap-chongqing.myqcloud.com/markdownPic/202301051756342.png)
**OK，I have completely fixed it！**
